### PR TITLE
修复因子内存、召唤石稀有度及 v1.7.4 UI 溢出

### DIFF
--- a/app.go
+++ b/app.go
@@ -122,6 +122,7 @@ type App struct {
 	terminusDropOrig    []byte
 	sigilMemoryHookAddr uintptr
 	sigilMemoryCaveAddr uintptr
+	sigilMemoryOriginal []byte
 	damageMeterMapping  windows.Handle
 	damageMeterView     uintptr
 	damageOverlay       *damageOverlayWindow
@@ -153,6 +154,7 @@ func (a *App) shutdown(ctx context.Context) {
 		a.damageOverlay.stop()
 	}
 	a.closeDamageMeter()
+	a.CharaDetach()
 }
 
 func (a *App) saveWindowSize(ctx context.Context) {
@@ -948,8 +950,7 @@ var potionDefs = []potionDef{
 func (a *App) CharaAttach() (CharaProcessInfo, error) {
 	// Close existing handle if any
 	if a.hProcess != 0 {
-		windows.CloseHandle(a.hProcess)
-		a.hProcess = 0
+		a.CharaDetach()
 	}
 
 	pid, err := findProcessByName(charaProcessName)
@@ -992,6 +993,10 @@ func (a *App) CharaAttach() (CharaProcessInfo, error) {
 
 // CharaDetach closes the process handle.
 func (a *App) CharaDetach() {
+	// Restore hooks while the target process is still available. Leaving the
+	// jump installed makes a later tool instance mistake it for an unsupported
+	// game build and can also leave the game executing tool-owned code.
+	_ = a.releaseSigilMemoryHook()
 	if a.hProcess != 0 {
 		windows.CloseHandle(a.hProcess)
 		a.hProcess = 0
@@ -1009,6 +1014,7 @@ func (a *App) CharaDetach() {
 	a.terminusDropOrig = nil
 	a.sigilMemoryHookAddr = 0
 	a.sigilMemoryCaveAddr = 0
+	a.sigilMemoryOriginal = nil
 }
 
 // CharaGetAll reads all character counts, returns valid characters (skipping empty slots).
@@ -1776,12 +1782,17 @@ func (a *App) CountdownSet(value float64) (CountdownStatus, error) {
 }
 
 func (a *App) ensureGameProcess() error {
-	if a.hProcess != 0 && a.moduleBase != 0 {
-		return nil
-	}
 	pid, err := findProcessByName(charaProcessName)
 	if err != nil {
 		return fmt.Errorf("未找到游戏进程，请先启动游戏")
+	}
+	if a.hProcess != 0 && a.moduleBase != 0 && a.charaPID == pid {
+		return nil
+	}
+	// The game was restarted while the tool stayed open. Drop every address
+	// derived from the old process before attaching to the new PID.
+	if a.hProcess != 0 || a.moduleBase != 0 || a.charaPID != 0 {
+		a.CharaDetach()
 	}
 	h, err := windows.OpenProcess(windows.PROCESS_ALL_ACCESS, false, pid)
 	if err != nil {

--- a/frontend/src/components/PatchTool.vue
+++ b/frontend/src/components/PatchTool.vue
@@ -298,8 +298,8 @@ function showStatus(msg, type) {
 
 <style scoped>
 .app-window { position:relative; display:flex; flex-direction:column; height:100vh; overflow:hidden; background:radial-gradient(ellipse at bottom, #12365c 0%, #06111f 52%, #020711 100%); border-radius:10px; box-shadow:0 8px 40px rgba(0,0,0,0.6); }
-.starfield { position:absolute; inset:0; overflow:hidden; pointer-events:none; z-index:0; }
-.stars { position:absolute; top:0; left:0; border-radius:50%; background:transparent; color:#fff; opacity:0.8; }
+.starfield { position:absolute; inset:0; overflow:hidden; pointer-events:none; z-index:0; opacity:0.34; }
+.stars { position:absolute; top:0; left:0; border-radius:50%; background:transparent; color:#d8efff; opacity:0.58; }
 .stars::after { content:""; position:absolute; top:100vh; left:0; border-radius:50%; background:transparent; color:#fff; }
 .stars-1,
 .stars-1::after { width:1px; height:1px; box-shadow: 6vw 9vh currentColor, 18vw 32vh currentColor, 28vw 14vh currentColor, 41vw 47vh currentColor, 54vw 7vh currentColor, 69vw 28vh currentColor, 82vw 19vh currentColor, 94vw 43vh currentColor, 12vw 71vh currentColor, 36vw 88vh currentColor, 61vw 64vh currentColor, 76vw 83vh currentColor, 90vw 72vh currentColor, 24vw 58vh currentColor, 49vw 79vh currentColor; animation: starDrift 46s linear infinite; }
@@ -312,34 +312,37 @@ function showStatus(msg, type) {
 
 .tab-bar {
   display: flex;
-  gap: 2px;
-  padding: 4px 14px;
+  gap: 0;
+  padding: 5px 8px;
   background: rgba(18,26,38,0.95);
   border-bottom: 1px solid rgba(255,255,255,0.06);
   flex-shrink: 0;
   overflow-x: auto;
   overflow-y: hidden;
-  scrollbar-width: thin;
+  scrollbar-width: none;
+  overscroll-behavior-x: contain;
 }
+.tab-bar::-webkit-scrollbar { display:none; }
 .tab-btn {
-  padding: 4px 14px;
+  padding: 5px 7px;
   border-radius: 6px;
   border: none;
   background: transparent;
-  color: rgba(255,255,255,0.35);
-  font-size: 0.76rem;
+  color: rgba(255,255,255,0.58);
+  font-size: 0.66rem;
   font-weight: 600;
   cursor: pointer;
   transition: background 0.15s, color 0.15s;
   white-space: nowrap;
-  flex-shrink: 0;
+  flex-shrink: 1;
 }
-.tab-btn:hover { color: rgba(255,255,255,0.6); background: rgba(255,255,255,0.05); }
+.tab-btn:hover { color: rgba(255,255,255,0.82); background: rgba(255,255,255,0.06); }
+.tab-btn:focus-visible { outline:1px solid rgba(103,232,249,0.58); outline-offset:-1px; }
 .tab-btn.active { color: #67e8f9; background: rgba(103,232,249,0.12); }
-.language-tab { margin-left: auto; }
+.language-tab { margin-left: 0; }
 .titlebar { display:flex; align-items:center; justify-content:space-between; height:38px; padding:0 6px 0 14px; background:rgba(18,26,38,0.95); border-bottom:1px solid rgba(255,255,255,0.06); flex-shrink:0; user-select:none; }
 .titlebar-left { display:flex; align-items:center; gap:8px; }
-.titlebar-title { font-size:0.8rem; font-weight:600; color:rgba(255,255,255,0.55); letter-spacing:0.5px; }
+.titlebar-title { font-size:0.8rem; font-weight:600; color:rgba(255,255,255,0.76); letter-spacing:0.5px; }
 .titlebar-controls { display:flex; align-items:center; gap:2px; }
 .win-btn { width:32px; height:28px; border:none; border-radius:6px; background:transparent; color:rgba(255,255,255,0.45); cursor:pointer; display:flex; align-items:center; justify-content:center; transition:background 0.15s,color 0.15s; }
 .win-btn.minimize:hover { background:rgba(255,255,255,0.1); color:rgba(255,255,255,0.9); }

--- a/frontend/src/components/SigilGenerator.vue
+++ b/frontend/src/components/SigilGenerator.vue
@@ -527,8 +527,8 @@ function onSecondaryTraitSelect() {
 .section {
   border-radius: 12px;
   padding: 14px 16px;
-  background: rgba(255,255,255,0.04);
-  border: 1px solid rgba(255,255,255,0.06);
+  background: rgba(13,27,44,0.9);
+  border: 1px solid rgba(148,190,220,0.13);
   display: flex;
   flex-direction: column;
   gap: 10px;
@@ -567,7 +567,7 @@ function onSecondaryTraitSelect() {
 .section-title {
   font-size: 0.78rem;
   font-weight: 600;
-  color: rgba(255,255,255,0.35);
+  color: rgba(226,241,255,0.68);
   letter-spacing: 1px;
   display: flex;
   align-items: center;
@@ -577,7 +577,7 @@ function onSecondaryTraitSelect() {
 .field { display: flex; flex-direction: column; gap: 4px; }
 .field label {
   font-size: 0.7rem;
-  color: rgba(255,255,255,0.3);
+  color: rgba(226,241,255,0.6);
 }
 
 .text-input, .select-input {
@@ -623,7 +623,7 @@ function onSecondaryTraitSelect() {
   border-radius: 8px;
   border: 1px solid rgba(255,255,255,0.08);
   background: rgba(255,255,255,0.03);
-  color: rgba(255,255,255,0.45);
+  color: rgba(255,255,255,0.68);
   font-size: 0.82rem;
 }
 
@@ -708,7 +708,7 @@ function onSecondaryTraitSelect() {
 
 .empty-hint {
   font-size: 0.75rem;
-  color: rgba(255,255,255,0.2);
+  color: rgba(255,255,255,0.48);
   text-align: center;
   padding: 8px 0;
 }
@@ -833,15 +833,15 @@ function onSecondaryTraitSelect() {
 .existing-header {
   background: rgba(255,255,255,0.06);
   font-size: 0.7rem;
-  color: rgba(255,255,255,0.3);
+  color: rgba(255,255,255,0.56);
   font-weight: 600;
   padding: 4px 10px;
 }
 .existing-row input[type="checkbox"] { accent-color: #67e8f9; cursor: pointer; }
 .ex-col-cb { width: 20px; flex-shrink: 0; text-align: center; }
 .ex-col-name { flex: 1; color: rgba(255,255,255,0.6); min-width: 0; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
-.ex-col-level { width: 40px; text-align: right; color: rgba(255,255,255,0.35); flex-shrink: 0; }
-.ex-col-trait { width: 160px; color: rgba(255,255,255,0.3); font-size: 0.7rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex-shrink: 0; }
+.ex-col-level { width: 40px; text-align: right; color: rgba(255,255,255,0.58); flex-shrink: 0; }
+.ex-col-trait { width: 160px; color: rgba(255,255,255,0.54); font-size: 0.7rem; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; flex-shrink: 0; }
 
 /* 队列列表 */
 .queue-list { display: flex; flex-direction: column; gap: 6px; }

--- a/frontend/src/components/SigilMemoryGenerator.vue
+++ b/frontend/src/components/SigilMemoryGenerator.vue
@@ -62,7 +62,7 @@ async function write() {
   try {
     const next = await SigilMemoryUpdate({ ...form })
     applyStatus(next, true)
-    show(`已写入并提交保存: ${next.sigilName}`, 'success')
+    show(`已写入并提交保存: ${next.sigilName}。请在游戏中重新选择下一个因子。`, 'success')
   } catch (e) { show(String(e), 'error') }
   finally { applying.value = false }
 }
@@ -81,7 +81,7 @@ onMounted(async () => { await loadOptions(); await refresh(true) })
         <button class="btn btn-cyan" :disabled="loading" @click="enable">{{ status.hooked ? '读取已开启' : '开启读取' }}</button>
         <button class="btn" :disabled="loading" @click="refresh(true)">{{ loading ? '读取中...' : '刷新选中因子' }}</button>
       </div>
-      <div class="hint">游戏内打开因子列表并选中目标因子。修改后切换选择或关闭界面触发游戏保存。</div>
+      <div class="hint">游戏内打开因子列表并选中目标因子。每次写入后必须重新选择目标，避免复用游戏重建背包前的旧地址。</div>
       <div class="state" :class="{ ready: status.selectedAddr }">
         {{ status.selectedAddr ? `已选中 ${hex(status.selectedAddr)}` : status.hooked ? '等待游戏内选中因子' : '未开启读取' }}
       </div>

--- a/frontend/src/components/SummonEditor.vue
+++ b/frontend/src/components/SummonEditor.vue
@@ -29,12 +29,17 @@ const filteredSummons = computed(() => {
     .some((value) => String(value).toLowerCase().includes(query)))
 })
 const selected = computed(() => summons.value.find((item) => item.index === selectedIndex.value))
+const rarityLabelsByCost = { 3: 'I', 4: 'II', 5: 'III' }
 
 function hex(value) { return '0x' + Number(value || 0).toString(16).toUpperCase().padStart(8, '0') }
 function nameForType(hash) { return typeByHash.value.get(hash)?.name || hex(hash) }
 function nameForTrait(hash) { return traitByHash.value.get(hash)?.name || (hash ? hex(hash) : '无') }
 function nameForSubParam(hash) { return subParamByHash.value.get(hash)?.name || (hash ? hex(hash) : '无') }
 function optionLabel(item) { return `${item.name} · ${hex(item.hash)}` }
+function rarityLabel(item) {
+  const cost = typeByHash.value.get(item.typeHash)?.cost
+  return rarityLabelsByCost[cost] || String(item.rank)
+}
 function parseHash(value, label) {
   const text = String(value).trim()
   const parsed = /^0x/i.test(text) ? Number.parseInt(text, 16) : Number.parseInt(text, 10)
@@ -116,7 +121,7 @@ function save() {
         <input v-model="filter" class="filter" placeholder="搜索名称或 Hash（更改类型无法写入存档）" />
         <div class="list">
           <button v-for="item in filteredSummons" :key="item.index" class="summon-row" :class="{ selected: item.index === selectedIndex }" @click="select(item)">
-            <span class="slot">#{{ item.index + 1 }}</span><span class="name">{{ nameForType(item.typeHash) }}</span><span class="rank">{{ ['-', 'I', 'II', 'III'][item.rank] || item.rank }}</span>
+            <span class="slot">#{{ item.index + 1 }}</span><span class="name">{{ nameForType(item.typeHash) }}</span><span class="rank">{{ rarityLabel(item) }}</span>
           </button>
           <p v-if="!summons.length" class="empty">未读取到召唤石。请打开游戏内召唤石背包后刷新。</p>
         </div>

--- a/sigil_memory.go
+++ b/sigil_memory.go
@@ -11,6 +11,7 @@ const (
 	sigilMemorySaveRVA        = uintptr(0x79D820)
 	sigilMemoryHookSize       = 8
 	sigilMemoryCaveDataOffset = uintptr(0x40)
+	sigilMemoryOriginalOffset = uintptr(13)
 )
 
 var (
@@ -120,7 +121,21 @@ func (a *App) SigilMemoryScan() (SigilMemoryStatus, error) {
 	if err := readProcessMemory(a.hProcess, addr, unsafe.Pointer(&first[0]), uintptr(len(first))); err != nil {
 		return SigilMemoryStatus{}, fmt.Errorf("读取选中因子指令失败: %w", err)
 	}
-	if first[0] != 0x31 || first[2] != 0x81 {
+	if isSigilMemoryOriginal(first) {
+		a.sigilMemoryOriginal = append(a.sigilMemoryOriginal[:0], first...)
+		a.sigilMemoryCaveAddr = 0
+	} else if isSigilMemoryJump(first) {
+		// A previous tool instance may have exited while the game stayed open.
+		// Adopt only a hook whose code cave has our exact prologue, then recover
+		// the displaced instructions so it can be safely removed on shutdown.
+		cave := relJumpTarget(addr, first)
+		original, err := a.recoverSigilMemoryHook(cave)
+		if err != nil {
+			return SigilMemoryStatus{}, fmt.Errorf("选中因子 Hook 无法接管: %w", err)
+		}
+		a.sigilMemoryCaveAddr = cave
+		a.sigilMemoryOriginal = original
+	} else {
 		return SigilMemoryStatus{}, fmt.Errorf("选中因子指令字节异常: %s", bytesToHex(first))
 	}
 	a.sigilMemoryHookAddr = addr
@@ -217,6 +232,7 @@ func (a *App) SigilMemoryEnable() (SigilMemoryStatus, error) {
 		return SigilMemoryStatus{}, fmt.Errorf("写入因子读取 Hook 失败: %w", err)
 	}
 	a.sigilMemoryCaveAddr = cave
+	a.sigilMemoryOriginal = append(a.sigilMemoryOriginal[:0], original...)
 	return a.readSigilMemoryStatus()
 }
 
@@ -253,7 +269,17 @@ func (a *App) SigilMemoryUpdate(update SigilMemoryUpdate) (SigilMemoryStatus, er
 	if err := a.saveSigilMemory(base); err != nil {
 		return SigilMemoryStatus{}, err
 	}
-	return a.readSigilMemoryStatus()
+	result, err := a.readSigilMemoryStatus()
+	if err != nil {
+		return SigilMemoryStatus{}, err
+	}
+	// Inventory storage can be rebuilt after rewards, sorting or scene changes.
+	// Never allow a later write to silently reuse this raw pointer.
+	if err := a.clearSigilMemorySelection(); err != nil {
+		return SigilMemoryStatus{}, err
+	}
+	result.SelectedAddr = 0
+	return result, nil
 }
 
 func (a *App) saveSigilMemory(base uintptr) error {
@@ -274,8 +300,8 @@ func (a *App) readSigilMemoryStatus() (SigilMemoryStatus, error) {
 	if err := readProcessMemory(a.hProcess, a.sigilMemoryHookAddr, unsafe.Pointer(&buf[0]), uintptr(len(buf))); err != nil {
 		return SigilMemoryStatus{}, fmt.Errorf("读取选中因子 Hook 指令失败: %w", err)
 	}
-	hooked := buf[0] == 0xE9 && buf[5] == 0x90 && buf[6] == 0x90 && buf[7] == 0x90
-	if !hooked && (buf[0] != 0x31 || buf[2] != 0x81) {
+	hooked := isSigilMemoryJump(buf)
+	if !hooked && !isSigilMemoryOriginal(buf) {
 		return SigilMemoryStatus{}, fmt.Errorf("选中因子指令字节异常: %s", bytesToHex(buf))
 	}
 
@@ -291,7 +317,13 @@ func (a *App) readSigilMemoryStatus() (SigilMemoryStatus, error) {
 		return status, nil
 	}
 	if a.sigilMemoryCaveAddr == 0 {
-		a.sigilMemoryCaveAddr = relJumpTarget(a.sigilMemoryHookAddr, buf)
+		cave := relJumpTarget(a.sigilMemoryHookAddr, buf)
+		original, err := a.recoverSigilMemoryHook(cave)
+		if err != nil {
+			return SigilMemoryStatus{}, fmt.Errorf("校验选中因子 Hook 失败: %w", err)
+		}
+		a.sigilMemoryCaveAddr = cave
+		a.sigilMemoryOriginal = original
 	}
 	var selected uintptr
 	if err := readProcessMemory(a.hProcess, a.sigilMemoryCaveAddr+sigilMemoryCaveDataOffset, unsafe.Pointer(&selected), unsafe.Sizeof(selected)); err != nil {
@@ -353,6 +385,81 @@ func (a *App) readSigilMemoryStatus() (SigilMemoryStatus, error) {
 		status.SecondaryTraitName = fmt.Sprintf("0x%08X", status.SecondaryTraitHash)
 	}
 	return status, nil
+}
+
+func isSigilMemoryOriginal(buf []byte) bool {
+	return len(buf) >= sigilMemoryHookSize && buf[0] == 0x31 && buf[2] == 0x81
+}
+
+func isSigilMemoryJump(buf []byte) bool {
+	return len(buf) >= sigilMemoryHookSize && buf[0] == 0xE9 && buf[5] == 0x90 && buf[6] == 0x90 && buf[7] == 0x90
+}
+
+func (a *App) recoverSigilMemoryHook(cave uintptr) ([]byte, error) {
+	if cave == 0 {
+		return nil, fmt.Errorf("代码洞地址为空")
+	}
+	prologue := make([]byte, sigilMemoryOriginalOffset)
+	if err := readProcessMemory(a.hProcess, cave, unsafe.Pointer(&prologue[0]), uintptr(len(prologue))); err != nil {
+		return nil, fmt.Errorf("读取代码洞失败: %w", err)
+	}
+	if prologue[0] != 0x49 || prologue[1] != 0xBA || prologue[10] != 0x49 || prologue[11] != 0x89 || prologue[12] != 0x02 {
+		return nil, fmt.Errorf("代码洞签名不匹配")
+	}
+	dataAddr := uintptr(binary.LittleEndian.Uint64(prologue[2:10]))
+	if dataAddr != cave+sigilMemoryCaveDataOffset {
+		return nil, fmt.Errorf("代码洞数据地址不匹配")
+	}
+	original := make([]byte, sigilMemoryHookSize)
+	if err := readProcessMemory(a.hProcess, cave+sigilMemoryOriginalOffset, unsafe.Pointer(&original[0]), uintptr(len(original))); err != nil {
+		return nil, fmt.Errorf("读取原始指令失败: %w", err)
+	}
+	if !isSigilMemoryOriginal(original) {
+		return nil, fmt.Errorf("原始指令签名不匹配: %s", bytesToHex(original))
+	}
+	return original, nil
+}
+
+func (a *App) clearSigilMemorySelection() error {
+	if a.hProcess == 0 || a.sigilMemoryCaveAddr == 0 {
+		return nil
+	}
+	var zero uintptr
+	if err := writeProcessMemory(a.hProcess, a.sigilMemoryCaveAddr+sigilMemoryCaveDataOffset, unsafe.Pointer(&zero), unsafe.Sizeof(zero)); err != nil {
+		return fmt.Errorf("清空旧的选中因子指针失败: %w", err)
+	}
+	return nil
+}
+
+func (a *App) releaseSigilMemoryHook() error {
+	if a.hProcess == 0 || a.sigilMemoryHookAddr == 0 {
+		return nil
+	}
+	current := make([]byte, sigilMemoryHookSize)
+	if err := readProcessMemory(a.hProcess, a.sigilMemoryHookAddr, unsafe.Pointer(&current[0]), uintptr(len(current))); err != nil {
+		return err
+	}
+	if !isSigilMemoryJump(current) {
+		return nil
+	}
+	cave := relJumpTarget(a.sigilMemoryHookAddr, current)
+	original := a.sigilMemoryOriginal
+	if len(original) != sigilMemoryHookSize {
+		var err error
+		original, err = a.recoverSigilMemoryHook(cave)
+		if err != nil {
+			return err
+		}
+	}
+	if err := writeCodeMemory(a.hProcess, a.sigilMemoryHookAddr, original); err != nil {
+		return fmt.Errorf("恢复选中因子原始指令失败: %w", err)
+	}
+	// Do not free the remote page here: a game thread may already be inside the
+	// cave. The OS reclaims this single page when the game exits.
+	a.sigilMemoryHookAddr = 0
+	a.sigilMemoryCaveAddr = 0
+	a.sigilMemoryOriginal = nil
+	return nil
 }
 
 func buildSigilMemoryCave(cave, returnAddr uintptr, original []byte) ([]byte, error) {


### PR DESCRIPTION
## 问题

在游戏中首次修改因子成功后，继续游玩、获得新因子、切换场景或重启游戏/工具，再次修改可能出现因子无法匹配、读取旧地址或指令字节异常：

- 选中因子的裸指针会长期保留，背包重建后可能失效。
- 工具关闭时未恢复因子 Hook；游戏保持运行并重新打开工具时，扫描只接受原始指令，无法识别遗留的 `E9` Hook。
- 游戏重启后，工具仅检查句柄是否非零，可能继续使用旧 PID 的句柄和派生地址。
- v1.7.4 增加语言标签后，默认 800px 窗口内标签总宽约 1030px，出现明显的系统横向滚动条；原有低透明度文字和星点穿透卡片也影响可读性。
- 召唤石列表直接把内存 `rank` 字段映射为罗马数字；该字段在不同稀有度记录中可能相同，导致所有召唤石显示成同一个级别。

## 修复

- 对遗留 Hook 的代码洞签名、数据地址和原始指令进行校验，校验通过后可安全接管。
- 保存被覆盖的原始指令，在 detach/shutdown 时恢复 Hook。
- 每次调用前核对游戏 PID；PID 改变时清理旧句柄和所有派生地址，再重新连接。
- 每次因子写入并保存后清空选中指针，要求用户重新选择目标，避免复用背包重建前的旧地址。
- 将 11 个导航标签压缩到 800px 单行内，隐藏原生滚动条，并改善因子生成页的文字对比度与背景层级，保持原有深蓝/青色风格。
- 召唤石稀有度改为使用类型表的 `cost` 显示：`3 → I（稀有）`、`4 → II（史诗）`、`5 → III（传说）`；内存 `rank` 字段继续原样保存，不再用于稀有度显示。

## 验证

- `go test ./...`
- `npm run build`
- `wails build -s`
- Windows 可执行文件启动冒烟测试通过
- 800×600 视口验证：tab bar `scrollWidth == clientWidth == 800`，无横向溢出
- `summons.json` 共 189 条记录，`cost` 仅包含 3/4/5 三档，并与稀有/史诗/传说对应
- 实际游戏会话中重复修改因子验证通过