### PR TITLE
完整修复召唤石副词条问题

### DIFF
--- a/data/summon_sub_params.json
+++ b/data/summon_sub_params.json
@@ -1,15 +1,400 @@
 {
   "subParams": [
-    { "hash": "0x5A39D81B", "displayName": "奥义连锁伤害" },
-    { "hash": "0x2270BC40", "displayName": "HP回复上限" },
-    { "hash": "0xF7B0316F", "displayName": "昏厥" },
-    { "hash": "0x75138D21", "displayName": "奥义伤害" },
-    { "hash": "0xA8900C80", "displayName": "攻击力" },
-    { "hash": "0x00D171E0", "displayName": "暴击率" },
-    { "hash": "0x664E8E32", "displayName": "能力伤害" },
-    { "hash": "0x2FFB509F", "displayName": "能力伤害上限" },
-    { "hash": "0xA3539FBB", "displayName": "奥义伤害上限" },
-    { "hash": "0xA66241C9", "displayName": "普通攻击伤害上限" },
-    { "hash": "0xBC4E92CB", "displayName": "HP" }
+    {
+      "hash": "0x5A39D81B",
+      "displayName": "奥义连锁伤害（低·最高50%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50
+      ]
+    },
+    {
+      "hash": "0x54B09A37",
+      "displayName": "奥义连锁伤害（高·最高100%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50,
+        60,
+        80,
+        100
+      ]
+    },
+    {
+      "hash": "0xBC4E92CB",
+      "displayName": "体力（低·最高2000）",
+      "maxLevel": 9,
+      "isPercent": false,
+      "values": [
+        200,
+        400,
+        600,
+        800,
+        1000,
+        1200,
+        1400,
+        1600,
+        1800,
+        2000
+      ]
+    },
+    {
+      "hash": "0xF2256E44",
+      "displayName": "体力（高·最高5000）",
+      "maxLevel": 9,
+      "isPercent": false,
+      "values": [
+        800,
+        1000,
+        1200,
+        1400,
+        1600,
+        1800,
+        2000,
+        2500,
+        3000,
+        5000
+      ]
+    },
+    {
+      "hash": "0xA3539FBB",
+      "displayName": "奥义伤害上限（低·最高50%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50
+      ]
+    },
+    {
+      "hash": "0x5A1D2C89",
+      "displayName": "奥义伤害上限（高·最高100%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50,
+        60,
+        80,
+        100
+      ]
+    },
+    {
+      "hash": "0x75138D21",
+      "displayName": "奥义伤害（低·最高20%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        2,
+        4,
+        6,
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20
+      ]
+    },
+    {
+      "hash": "0x33C0D50C",
+      "displayName": "奥义伤害（高·最高30%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20,
+        22,
+        25,
+        30
+      ]
+    },
+    {
+      "hash": "0xA8900C80",
+      "displayName": "攻击力（低·最高2000）",
+      "maxLevel": 9,
+      "isPercent": false,
+      "values": [
+        200,
+        400,
+        600,
+        800,
+        1000,
+        1200,
+        1400,
+        1600,
+        1800,
+        2000
+      ]
+    },
+    {
+      "hash": "0xA3E537B1",
+      "displayName": "攻击力（高·最高3000）",
+      "maxLevel": 9,
+      "isPercent": false,
+      "values": [
+        800,
+        1000,
+        1200,
+        1400,
+        1600,
+        1800,
+        2000,
+        2200,
+        2500,
+        3000
+      ]
+    },
+    {
+      "hash": "0xF7B0316F",
+      "displayName": "昏厥（低·最高1.5）",
+      "maxLevel": 9,
+      "isPercent": false,
+      "values": [
+        0.2,
+        0.3,
+        0.4,
+        0.5,
+        0.6,
+        0.7,
+        0.9,
+        1.1,
+        1.3,
+        1.5
+      ]
+    },
+    {
+      "hash": "0xF0F77BC1",
+      "displayName": "昏厥（高·最高2）",
+      "maxLevel": 9,
+      "isPercent": false,
+      "values": [
+        0.5,
+        0.6,
+        0.7,
+        0.9,
+        1.1,
+        1.3,
+        1.5,
+        1.6,
+        1.8,
+        2
+      ]
+    },
+    {
+      "hash": "0xA66241C9",
+      "displayName": "普通攻击伤害上限（低·最高50%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50
+      ]
+    },
+    {
+      "hash": "0x9245DFA4",
+      "displayName": "普通攻击伤害上限（高·最高100%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50,
+        60,
+        80,
+        100
+      ]
+    },
+    {
+      "hash": "0x00D171E0",
+      "displayName": "暴击率（低·最高20%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        2,
+        4,
+        6,
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20
+      ]
+    },
+    {
+      "hash": "0xA074A967",
+      "displayName": "暴击率（高·最高30%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20,
+        22,
+        25,
+        30
+      ]
+    },
+    {
+      "hash": "0x2270BC40",
+      "displayName": "HP回复上限（低·最高50%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50
+      ]
+    },
+    {
+      "hash": "0x2EA9CA80",
+      "displayName": "HP回复上限（高·最高75%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50,
+        55,
+        60,
+        75
+      ]
+    },
+    {
+      "hash": "0x2FFB509F",
+      "displayName": "能力伤害上限（低·最高50%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        5,
+        10,
+        15,
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50
+      ]
+    },
+    {
+      "hash": "0xCE70C58A",
+      "displayName": "能力伤害上限（高·最高100%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        20,
+        25,
+        30,
+        35,
+        40,
+        45,
+        50,
+        60,
+        80,
+        100
+      ]
+    },
+    {
+      "hash": "0x664E8E32",
+      "displayName": "能力伤害（低·最高20%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        2,
+        4,
+        6,
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20
+      ]
+    },
+    {
+      "hash": "0xAF39A3FB",
+      "displayName": "能力伤害（高·最高30%）",
+      "maxLevel": 9,
+      "isPercent": true,
+      "values": [
+        8,
+        10,
+        12,
+        14,
+        16,
+        18,
+        20,
+        22,
+        25,
+        30
+      ]
+    }
   ]
 }

--- a/frontend/src/components/SummonEditor.vue
+++ b/frontend/src/components/SummonEditor.vue
@@ -1,5 +1,5 @@
 <script setup>
-import { computed, reactive, ref } from 'vue'
+import { computed, reactive, ref, watch } from 'vue'
 import { CharaAttach, SummonGetAll, SummonGetOptions, SummonUpdate } from '../../wailsjs/go/main/App'
 import { matchText } from '../utils/matchText.js'
 
@@ -18,6 +18,25 @@ const edit = reactive({ typeHash: '', mainTraitHash: '', subParamHash: '', mainT
 const typeByHash = computed(() => new Map(options.types.map((item) => [item.hash, item])))
 const traitByHash = computed(() => new Map(options.traits.map((item) => [item.hash, item])))
 const subParamByHash = computed(() => new Map(options.subParams.map((item) => [item.hash, item])))
+const currentSubParam = computed(() => {
+  const h = Number.parseInt(String(edit.subParamHash).trim(), 16)
+  return Number.isNaN(h) ? null : subParamByHash.value.get(h) || null
+})
+const subParamMaxLevel = computed(() => {
+  const sp = currentSubParam.value
+  return sp && Number.isInteger(sp.maxLevel) && sp.maxLevel > 0 ? sp.maxLevel : 9
+})
+function subParamValueLabel(level) {
+  const sp = currentSubParam.value
+  const idx = Number.parseInt(level, 10)
+  if (!sp || !Array.isArray(sp.values) || idx < 0 || idx >= sp.values.length) return String(idx)
+  const v = sp.values[idx]
+  return sp.isPercent ? `${idx} → +${v}%` : `${idx} → +${v}`
+}
+// 切换副参数后, 若当前档位超出新副参数上限则钳制, 避免下拉显示空值
+watch(subParamMaxLevel, (max) => {
+  if (Number.parseInt(edit.subParamLevel, 10) > max) edit.subParamLevel = String(max)
+})
 const filteredTraits = computed(() => {
   const query = traitFilter.value.trim()
   if (!query) return options.traits
@@ -89,7 +108,7 @@ function save() {
       rank: Number.parseInt(edit.rank, 10),
     }
     if (!Number.isInteger(update.mainTraitLevel) || update.mainTraitLevel < 0 || update.mainTraitLevel > traitMax(mainTraitHash)) throw new Error(`主因子等级必须为 0 到 ${traitMax(mainTraitHash)}`)
-    if (!Number.isInteger(update.subParamLevel) || update.subParamLevel < 0 || update.subParamLevel > 999) throw new Error('副参数等级必须为 0 到 999')
+    if (!Number.isInteger(update.subParamLevel) || update.subParamLevel < 0 || update.subParamLevel > subParamMaxLevel.value) throw new Error(`副参数等级必须为 0 到 ${subParamMaxLevel.value}`)
   } catch (err) {
     emit('status', String(err.message || err), 'error')
     return
@@ -136,7 +155,7 @@ function save() {
           <label>主因子<select v-model="edit.mainTraitHash"><option v-for="item in filteredTraits" :key="item.hash" :value="hex(item.hash)">{{ optionLabel(item) }}</option></select></label>
           <label>主因子等级<input v-model="edit.mainTraitLevel" type="number" min="0" :max="traitMax(edit.mainTraitHash)" /></label>
           <label>副参数<select v-model="edit.subParamHash"><option v-for="item in options.subParams" :key="item.hash" :value="hex(item.hash)">{{ optionLabel(item) }}</option></select></label>
-          <label>副参数等级<select v-model="edit.subParamLevel"><option v-for="level in 10" :key="level - 1" :value="String(level - 1)">{{ level - 1 }}</option></select></label>
+          <label>副参数等级<select v-model="edit.subParamLevel"><option v-for="level in (subParamMaxLevel + 1)" :key="level - 1" :value="String(level - 1)">{{ subParamValueLabel(level - 1) }}</option></select></label>
           <button class="save" @click="save" :disabled="saving">{{ saving ? '写入中...' : '写入召唤石' }}</button>
         </template>
         <p v-else class="empty">从左侧选择召唤石。</p>

--- a/summon_memory.go
+++ b/summon_memory.go
@@ -83,8 +83,11 @@ type summonSkillFile struct {
 
 type summonSubParamFile struct {
 	SubParams []struct {
-		Hash        string `json:"hash"`
-		DisplayName string `json:"displayName"`
+		Hash        string    `json:"hash"`
+		DisplayName string    `json:"displayName"`
+		MaxLevel    int       `json:"maxLevel"`
+		IsPercent   bool      `json:"isPercent"`
+		Values      []float64 `json:"values"`
 	} `json:"subParams"`
 }
 
@@ -121,10 +124,30 @@ func (a *App) SummonGetOptions() (SummonOptions, error) {
 	for _, item := range subParams.SubParams {
 		hash, err := ParseHashHex(item.Hash)
 		if err == nil {
-			options.SubParams = append(options.SubParams, SummonOption{Hash: hash, Name: item.DisplayName})
+			options.SubParams = append(options.SubParams, SummonOption{
+				Hash:      hash,
+				Name:      item.DisplayName,
+				MaxLevel:  item.MaxLevel,
+				IsPercent: item.IsPercent,
+				Values:    item.Values,
+			})
 		}
 	}
 	return options, nil
+}
+
+func (a *App) summonSubParamMaxLevel(hash uint32) (int, bool) {
+	var subParams summonSubParamFile
+	if err := json.Unmarshal(summonSubParamsJSON, &subParams); err != nil {
+		return 0, false
+	}
+	for _, item := range subParams.SubParams {
+		h, err := ParseHashHex(item.Hash)
+		if err == nil && h == hash {
+			return item.MaxLevel, true
+		}
+	}
+	return 0, false
 }
 
 func (a *App) summonInventoryAddress() (uintptr, error) {
@@ -190,6 +213,12 @@ func (a *App) SummonUpdate(item SummonUpdate) (SummonInfo, error) {
 	}
 	if item.MainTraitLevel > math.MaxInt32 || item.SubParamLevel > math.MaxInt32 {
 		return SummonInfo{}, fmt.Errorf("召唤石等级或副参数等级超出范围")
+	}
+	// 副参数等级是档位索引(0~maxLevel), 超出会越界读到相邻档位表导致数值溢出, 按该副参数上限钳制。
+	if item.SubParamHash != 0 {
+		if max, ok := a.summonSubParamMaxLevel(item.SubParamHash); ok && item.SubParamLevel > uint32(max) {
+			return SummonInfo{}, fmt.Errorf("副参数等级超出上限，应为 0 到 %d", max)
+		}
 	}
 
 	inventory, err := a.summonInventoryAddress()


### PR DESCRIPTION
副词条数据只有11条且缺档位表, 档位填超过实际档位数时越界导致数值溢出。

- 补全副词条为22条(11种各低/高两档), 每条带 values 档位表/maxLevel/isPercent
- 后端按 maxLevel 钳制档位, 拦截越界写入
- 前端档位下拉按真实档位数生成并显示换算值, 切换副词条自动钳制