### PR TITLE
适配游戏 2.0.3：修复因子生成-新 / 祝福生成-新内存偏移

### DIFF
--- a/internal/backend/sigil_memory.go
+++ b/internal/backend/sigil_memory.go
@@ -10,8 +10,8 @@ import (
 )
 
 const (
-	sigilMemoryHookRVA              = uintptr(0x345157)
-	sigilMemorySaveRVA              = uintptr(0x79D820)
+	sigilMemoryHookRVA              = uintptr(0x33E427) // 2.0.3; was 0x345157 on 2.0.2
+	sigilMemorySaveRVA              = uintptr(0x796E60) // 2.0.3; was 0x79D820 on 2.0.2
 	sigilMemoryHookSize             = 8
 	sigilMemoryCaveDataOffset       = uintptr(0x40)
 	sigilMemoryOriginalOffset       = uintptr(17)

--- a/internal/backend/wrightstone_memory.go
+++ b/internal/backend/wrightstone_memory.go
@@ -10,11 +10,11 @@ import (
 )
 
 const (
-	// This DLC 2.0.2 instruction captures RDX while the game opens or refreshes
+	// This DLC 2.0.3 instruction captures RDX while the game opens or refreshes
 	// the currently viewed wrightstone record. The RVA and full instruction
-	// window below were independently matched in the local 2.0.2 executable.
-	wrightstoneMemoryHookRVA        = uintptr(0x361CB4)
-	wrightstoneMemorySaveRVA        = uintptr(0x79D820)
+	// window below were independently matched in the local 2.0.3 executable.
+	wrightstoneMemoryHookRVA        = uintptr(0x35AF84) // 2.0.3; was 0x361CB4 on 2.0.2
+	wrightstoneMemorySaveRVA        = uintptr(0x796E60) // 2.0.3; was 0x79D820 on 2.0.2
 	wrightstoneMemoryHookSize       = uintptr(6)
 	wrightstoneMemoryCaveDataOffset = uintptr(0x40)
 	wrightstoneMemoryOriginalOffset = uintptr(17)
@@ -120,7 +120,7 @@ func (a *App) scanWrightstoneMemoryLocked() (WrightstoneMemoryStatus, error) {
 		// The save function uses a version-specific fixed RVA too. Relocating only
 		// this hook from an eight-byte match would create a false sense of version
 		// compatibility and could later start a thread at the wrong function.
-		return WrightstoneMemoryStatus{}, fmt.Errorf("祝福焦点指令字节异常 (%s)：当前游戏版本未通过 2.0.2 / DLC 2.0.2 runtime catalog 完整守卫", bytesToHex(guard))
+		return WrightstoneMemoryStatus{}, fmt.Errorf("祝福焦点指令字节异常 (%s)：当前游戏版本未通过 2.0.3 runtime catalog 完整守卫", bytesToHex(guard))
 	}
 
 	a.wrightstoneMemoryHookAddr = addr
@@ -558,7 +558,7 @@ func newWrightstoneMemoryStatus(found, hooked bool, hookAddr, moduleBase uintptr
 		SaveRVA:       uint64(wrightstoneMemorySaveRVA),
 		CurrentBytes:  bytesToHex(current),
 		CaptureSource: "dlcSupplement-current-view",
-		SourceVersion: "2.0.2",
+		SourceVersion: "2.0.3",
 	}
 }
 

--- a/sigil_memory.go
+++ b/sigil_memory.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	sigilMemoryHookRVA        = uintptr(0x345157)
-	sigilMemorySaveRVA        = uintptr(0x79D820)
+	sigilMemoryHookRVA        = uintptr(0x33E427) // 2.0.3; was 0x345157 on 2.0.2
+	sigilMemorySaveRVA        = uintptr(0x796E60) // 2.0.3; was 0x79D820 on 2.0.2
 	sigilMemoryHookSize       = 8
 	sigilMemoryCaveDataOffset = uintptr(0x40)
 	sigilMemoryOriginalOffset = uintptr(13)
@@ -152,7 +152,7 @@ func (a *App) SigilMemoryScan() (SigilMemoryStatus, error) {
 	if err := a.ensureGameProcess(); err != nil {
 		return SigilMemoryStatus{}, err
 	}
-	// Current game build verified at granblue_fantasy_relink.exe+345157.
+	// Current game build (2.0.3) verified at granblue_fantasy_relink.exe+33E427.
 	// Its first 8 bytes are safe to validate and hook; later bytes vary by build.
 	addr := a.moduleBase + sigilMemoryHookRVA
 	first := make([]byte, sigilMemoryHookSize)
@@ -214,7 +214,7 @@ func (a *App) scanSigilMemoryPattern() (uintptr, error) {
 	if len(matches) == 0 {
 		return 0, fmt.Errorf("未找到选中因子特征码；当前游戏版本与内置特征不匹配")
 	}
-	// Runtime breakpoint verification: later duplicate (+345157 in current build)
+	// Runtime breakpoint verification: later duplicate (+33E427 in 2.0.3)
 	// receives RAX pointing to the selected sigil structure.
 	return matches[len(matches)-1], nil
 }

--- a/wrightstone_memory.go
+++ b/wrightstone_memory.go
@@ -7,8 +7,8 @@ import (
 )
 
 const (
-	wrightstoneMemoryHookRVA        = uintptr(0x3222CF)
-	wrightstoneMemorySaveRVA        = uintptr(0x79D820)
+	wrightstoneMemoryHookRVA        = uintptr(0x31B59F) // 2.0.3; was 0x3222CF on 2.0.2
+	wrightstoneMemorySaveRVA        = uintptr(0x796E60) // 2.0.3; was 0x79D820 on 2.0.2
 	wrightstoneMemoryHookSize       = 8
 	wrightstoneMemoryCaveDataOffset = uintptr(0x40)
 )


### PR DESCRIPTION
## 摘要
- 针对游戏 **2.0.3**，更新「因子生成-新」的选中 Hook 与保存函数 RVA
- 同步更新「祝福生成-新」（含根目录入口与 `internal/backend`）的 Hook / Save RVA
- 未改动货币、召唤石及其他杂项，其余功能仍按上游 v1.9.5 处理

## 变更说明
| 功能 | Hook RVA | Save RVA |
|------|----------|----------|
| 因子生成-新 | `0x345157` → `0x33E427` | `0x79D820` → `0x796E60` |
| 祝福生成-新（主入口） | `0x3222CF` → `0x31B59F` | `0x79D820` → `0x796E60` |
| 祝福生成-新（backend） | `0x361CB4` → `0x35AF84` | `0x79D820` → `0x796E60` |

标定依据：本地 `granblue_fantasy_relink.exe` 产品版本 2.0.3。

## 测试计划
- [x] 启动游戏 2.0.3，进入存档
- [x] 「因子生成-新」：开启读取 → 游戏内选中因子 → 刷新/写入后确认生效
- [x] 「祝福生成-新」：开启读取 → 游戏内选中祝福 → 刷新/写入后确认生效
- [x] 确认未误改召唤石、货币等其他运行时功能