### PR TITLE
优化：因子/祝福生成-新改为纯 AOB 扫描，去掉固定 RVA

### DIFF
--- a/app.go
+++ b/app.go
@@ -130,6 +130,7 @@ type App struct {
 	wrightstoneMemoryHookAddr  uintptr
 	wrightstoneMemoryCaveAddr  uintptr
 	wrightstoneMemoryOriginal  []byte
+	itemSaveFunctionAddr       uintptr // AOB-resolved shared inventory save fn
 	summonMemoryHookAddr       uintptr
 	summonMemoryCaveAddr       uintptr
 	summonMemoryPointerAddr    uintptr
@@ -1252,6 +1253,7 @@ func (a *App) CharaDetach() {
 	a.summonMemoryCaveAddr = 0
 	a.summonMemoryPointerAddr = 0
 	a.summonMemoryOriginal = nil
+	a.itemSaveFunctionAddr = 0
 }
 
 // CharaGetAll reads all character counts, returns valid characters (skipping empty slots).
@@ -2180,10 +2182,10 @@ func (a *App) scanCountdownPattern() (uintptr, error) {
 	return a.scanPatternUnique(countdownPattern, countdownMask, "倒计时特征")
 }
 
-func (a *App) scanPatternUnique(pattern []byte, mask []bool, label string) (uintptr, error) {
+func (a *App) scanPatternAll(pattern []byte, mask []bool) ([]uintptr, error) {
 	moduleSize, err := getRemoteModuleSize(a.hProcess, a.moduleBase)
 	if err != nil {
-		return 0, err
+		return nil, err
 	}
 	const chunkSize uintptr = 0x10000
 	patternLen := len(pattern)
@@ -2210,9 +2212,6 @@ func (a *App) scanPatternUnique(pattern []byte, mask []bool, label string) (uint
 			scanBase = carryBase
 		}
 		matches = append(matches, findPatternMatches(scanBuf, scanBase, pattern, mask)...)
-		if len(matches) > 1 {
-			return 0, fmt.Errorf("%s命中多个位置: %d", label, len(matches))
-		}
 
 		if len(buf) >= patternLen-1 {
 			carry = append([]byte{}, buf[len(buf)-patternLen+1:]...)
@@ -2225,9 +2224,19 @@ func (a *App) scanPatternUnique(pattern []byte, mask []bool, label string) (uint
 			}
 		}
 	}
+	return matches, nil
+}
 
+func (a *App) scanPatternUnique(pattern []byte, mask []bool, label string) (uintptr, error) {
+	matches, err := a.scanPatternAll(pattern, mask)
+	if err != nil {
+		return 0, err
+	}
 	if len(matches) == 0 {
 		return 0, fmt.Errorf("未找到%s码", label)
+	}
+	if len(matches) > 1 {
+		return 0, fmt.Errorf("%s命中多个位置: %d", label, len(matches))
 	}
 	return matches[0], nil
 }

--- a/item_save_memory.go
+++ b/item_save_memory.go
@@ -1,0 +1,56 @@
+package main
+
+import (
+	"fmt"
+	"unsafe"
+)
+
+// Prologue plus the following test distinguishes the inventory field-save helper
+// from other functions that share the same stack frame setup.
+var (
+	itemSaveFunctionPattern = []byte{
+		0x55, 0x48, 0x83, 0xEC, 0x60, 0x48, 0x8D, 0x6C, 0x24, 0x60,
+		0x48, 0xC7, 0x45, 0xF8, 0xFE, 0xFF, 0xFF, 0xFF,
+		0x48, 0x8B, 0x05, 0, 0, 0, 0,
+		0x48, 0x85, 0xC0,
+	}
+	itemSaveFunctionMask = []bool{
+		true, true, true, true, true, true, true, true, true, true,
+		true, true, true, true, true, true, true, true,
+		true, true, true, false, false, false, false,
+		true, true, true,
+	}
+)
+
+func (a *App) resolveItemSaveFunction() (uintptr, error) {
+	if a.hProcess == 0 || a.moduleBase == 0 {
+		return 0, fmt.Errorf("未连接游戏进程")
+	}
+	if a.itemSaveFunctionAddr != 0 {
+		if err := a.validateItemSaveFunction(a.itemSaveFunctionAddr); err == nil {
+			return a.itemSaveFunctionAddr, nil
+		}
+		a.itemSaveFunctionAddr = 0
+	}
+
+	addr, err := a.scanPatternUnique(itemSaveFunctionPattern, itemSaveFunctionMask, "物品保存函数特征")
+	if err != nil {
+		return 0, err
+	}
+	if err := a.validateItemSaveFunction(addr); err != nil {
+		return 0, err
+	}
+	a.itemSaveFunctionAddr = addr
+	return addr, nil
+}
+
+func (a *App) validateItemSaveFunction(addr uintptr) error {
+	buf := make([]byte, len(itemSaveFunctionPattern))
+	if err := readProcessMemory(a.hProcess, addr, unsafe.Pointer(&buf[0]), uintptr(len(buf))); err != nil {
+		return fmt.Errorf("读取物品保存函数失败: %w", err)
+	}
+	if !matchPattern(buf, itemSaveFunctionPattern, itemSaveFunctionMask) {
+		return fmt.Errorf("物品保存函数特征不匹配: %s", bytesToHex(buf[:18]))
+	}
+	return nil
+}

--- a/sigil_memory.go
+++ b/sigil_memory.go
@@ -7,23 +7,24 @@ import (
 )
 
 const (
-	sigilMemoryHookRVA        = uintptr(0x33E427) // 2.0.3; was 0x345157 on 2.0.2
-	sigilMemorySaveRVA        = uintptr(0x796E60) // 2.0.3; was 0x79D820 on 2.0.2
 	sigilMemoryHookSize       = 8
 	sigilMemoryCaveDataOffset = uintptr(0x40)
 	sigilMemoryOriginalOffset = uintptr(13)
 )
 
 var (
-	// CT v0.4.5 used `01 ?? 83`; current game build inserts `31 C0` before cmp.
-	// First cmp is `81 /7 imm32` (six bytes total), second is `81 /7 disp8 imm32` (seven bytes).
+	// Selected-sigil gate: compare primary/secondary trait slots against the
+	// empty hash 0x887AE0B0, then add+xor+cmp edx,2. Multiple near-duplicates
+	// exist; take the last module hit (verified to receive RAX = selected record).
 	sigilMemorySelectedPattern = []byte{
-		0x31, 0, 0x81, 0, 0, 0, 0, 0x0F, 0x95, 0,
-		0x31, 0, 0x81, 0, 0, 0, 0, 0, 0x0F, 0x95, 0, 0x01, 0, 0x31, 0, 0x83,
+		0x31, 0xC9, 0x81, 0x38, 0xB0, 0xE0, 0x7A, 0x88, 0x0F, 0x95, 0xC1,
+		0x31, 0xD2, 0x81, 0x78, 0x08, 0xB0, 0xE0, 0x7A, 0x88, 0x0F, 0x95, 0xC2,
+		0x01, 0, 0x31, 0, 0x83,
 	}
 	sigilMemorySelectedMask = []bool{
-		true, false, true, false, false, false, false, false, true, true, false,
-		true, false, true, false, false, false, false, false, true, true, false, true, false, true, false, true,
+		true, true, true, true, true, true, true, true, true, true, true,
+		true, true, true, true, true, true, true, true, true, true, true, true,
+		true, false, true, false, true,
 	}
 )
 
@@ -152,9 +153,10 @@ func (a *App) SigilMemoryScan() (SigilMemoryStatus, error) {
 	if err := a.ensureGameProcess(); err != nil {
 		return SigilMemoryStatus{}, err
 	}
-	// Current game build (2.0.3) verified at granblue_fantasy_relink.exe+33E427.
-	// Its first 8 bytes are safe to validate and hook; later bytes vary by build.
-	addr := a.moduleBase + sigilMemoryHookRVA
+	addr, err := a.resolveSigilMemoryHook()
+	if err != nil {
+		return SigilMemoryStatus{}, err
+	}
 	first := make([]byte, sigilMemoryHookSize)
 	if err := readProcessMemory(a.hProcess, addr, unsafe.Pointer(&first[0]), uintptr(len(first))); err != nil {
 		return SigilMemoryStatus{}, fmt.Errorf("读取选中因子指令失败: %w", err)
@@ -180,43 +182,28 @@ func (a *App) SigilMemoryScan() (SigilMemoryStatus, error) {
 	return a.readSigilMemoryStatus()
 }
 
+func (a *App) resolveSigilMemoryHook() (uintptr, error) {
+	return a.scanSigilMemoryPattern()
+}
+
 func (a *App) scanSigilMemoryPattern() (uintptr, error) {
-	moduleSize, err := getRemoteModuleSize(a.hProcess, a.moduleBase)
+	// Wildcard the first hook-sized bytes so both pristine and already-hooked
+	// sites still match the rest of the uniqueness window.
+	matches, err := a.scanPatternAll(sigilMemorySelectedPattern, sigilMemoryHookedMask())
 	if err != nil {
 		return 0, err
 	}
-	const chunkSize uintptr = 0x10000
-	var matches []uintptr
-	var carry []byte
-	var carryBase uintptr
-	for off := uintptr(0); off < moduleSize; off += chunkSize {
-		size := chunkSize
-		if off+size > moduleSize {
-			size = moduleSize - off
-		}
-		buf := make([]byte, size)
-		addr := a.moduleBase + off
-		if err := readProcessMemory(a.hProcess, addr, unsafe.Pointer(&buf[0]), uintptr(len(buf))); err != nil {
-			carry = nil
+	for i := len(matches) - 1; i >= 0; i-- {
+		addr := matches[i]
+		probe := make([]byte, sigilMemoryHookSize)
+		if err := readProcessMemory(a.hProcess, addr, unsafe.Pointer(&probe[0]), uintptr(len(probe))); err != nil {
 			continue
 		}
-		scanBuf, scanBase := buf, addr
-		if len(carry) > 0 {
-			scanBuf = append(append([]byte{}, carry...), buf...)
-			scanBase = carryBase
-		}
-		matches = append(matches, findPatternMatches(scanBuf, scanBase, sigilMemorySelectedPattern, sigilMemorySelectedMask)...)
-		if len(buf) >= len(sigilMemorySelectedPattern)-1 {
-			carry = append([]byte{}, buf[len(buf)-len(sigilMemorySelectedPattern)+1:]...)
-			carryBase = addr + uintptr(len(buf)-len(sigilMemorySelectedPattern)+1)
+		if isSigilMemoryOriginal(probe) || isSigilMemoryJump(probe) {
+			return addr, nil
 		}
 	}
-	if len(matches) == 0 {
-		return 0, fmt.Errorf("未找到选中因子特征码；当前游戏版本与内置特征不匹配")
-	}
-	// Runtime breakpoint verification: later duplicate (+33E427 in 2.0.3)
-	// receives RAX pointing to the selected sigil structure.
-	return matches[len(matches)-1], nil
+	return 0, fmt.Errorf("未找到选中因子特征码；当前游戏版本与内置特征不匹配")
 }
 
 func (a *App) SigilMemoryGetStatus() (SigilMemoryStatus, error) {
@@ -321,7 +308,10 @@ func (a *App) SigilMemoryUpdate(update SigilMemoryUpdate) (SigilMemoryStatus, er
 }
 
 func (a *App) saveSigilMemory(base uintptr) error {
-	fn := a.moduleBase + sigilMemorySaveRVA
+	fn, err := a.resolveItemSaveFunction()
+	if err != nil {
+		return err
+	}
 	for offset := uintptr(0); offset <= 0x20; offset += 4 {
 		if err := a.callRemoteOneArg(fn, base+offset); err != nil {
 			return fmt.Errorf("保存因子字段 +0x%02X 失败: %w", offset, err)
@@ -348,8 +338,10 @@ func (a *App) readSigilMemoryStatus() (SigilMemoryStatus, error) {
 		Hooked:       hooked,
 		Address:      uint64(a.sigilMemoryHookAddr),
 		RVA:          uint64(a.sigilMemoryHookAddr - a.moduleBase),
-		SaveRVA:      uint64(sigilMemorySaveRVA),
 		CurrentBytes: bytesToHex(buf),
+	}
+	if saveFn, err := a.resolveItemSaveFunction(); err == nil {
+		status.SaveRVA = uint64(saveFn - a.moduleBase)
 	}
 	if !hooked {
 		return status, nil

--- a/wrightstone_memory.go
+++ b/wrightstone_memory.go
@@ -7,10 +7,31 @@ import (
 )
 
 const (
-	wrightstoneMemoryHookRVA        = uintptr(0x31B59F) // 2.0.3; was 0x3222CF on 2.0.2
-	wrightstoneMemorySaveRVA        = uintptr(0x796E60) // 2.0.3; was 0x79D820 on 2.0.2
 	wrightstoneMemoryHookSize       = 8
 	wrightstoneMemoryCaveDataOffset = uintptr(0x40)
+)
+
+// Unique wrightstone trait-copy helper: six dword fields (+0x00..+0x14) then
+// restore rax/epilogue. Relative CALL bytes are wildcards.
+var (
+	wrightstoneMemorySelectedPattern = []byte{
+		0x8B, 0x02, 0x39, 0x06, 0x74, 0x0A, 0x89, 0x06, 0x48, 0x89, 0xF1, 0xE8, 0, 0, 0, 0,
+		0x8B, 0x47, 0x04, 0x39, 0x46, 0x04, 0x74, 0x0B, 0x48, 0x8D, 0x4E, 0x04, 0x89, 0x01, 0xE8, 0, 0, 0, 0,
+		0x8B, 0x47, 0x08, 0x39, 0x46, 0x08, 0x74, 0x0B, 0x48, 0x8D, 0x4E, 0x08, 0x89, 0x01, 0xE8, 0, 0, 0, 0,
+		0x8B, 0x47, 0x0C, 0x39, 0x46, 0x0C, 0x74, 0x0B, 0x48, 0x8D, 0x4E, 0x0C, 0x89, 0x01, 0xE8, 0, 0, 0, 0,
+		0x8B, 0x47, 0x10, 0x39, 0x46, 0x10, 0x74, 0x0B, 0x48, 0x8D, 0x4E, 0x10, 0x89, 0x01, 0xE8, 0, 0, 0, 0,
+		0x8B, 0x47, 0x14, 0x39, 0x46, 0x14, 0x74, 0x0B, 0x48, 0x8D, 0x4E, 0x14, 0x89, 0x01, 0xE8, 0, 0, 0, 0,
+		0x48, 0x89, 0xF0, 0x48, 0x83, 0xC4, 0x30, 0x5F, 0x5E, 0x5D, 0xC3,
+	}
+	wrightstoneMemorySelectedMask = []bool{
+		true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false,
+		true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false,
+		true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false,
+		true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false,
+		true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false,
+		true, true, true, true, true, true, true, true, true, true, true, true, true, true, true, false, false, false, false,
+		true, true, true, true, true, true, true, true, true, true, true,
+	}
 )
 
 type WrightstoneMemoryOption struct {
@@ -64,7 +85,11 @@ func (a *App) WrightstoneMemoryGetStatus() (WrightstoneMemoryStatus, error) {
 		return WrightstoneMemoryStatus{}, err
 	}
 	if a.wrightstoneMemoryHookAddr == 0 {
-		a.wrightstoneMemoryHookAddr = a.moduleBase + wrightstoneMemoryHookRVA
+		addr, err := a.resolveWrightstoneMemoryHook()
+		if err != nil {
+			return WrightstoneMemoryStatus{}, err
+		}
+		a.wrightstoneMemoryHookAddr = addr
 		original := make([]byte, wrightstoneMemoryHookSize)
 		if err := readProcessMemory(a.hProcess, a.wrightstoneMemoryHookAddr, unsafe.Pointer(&original[0]), uintptr(len(original))); err != nil {
 			return WrightstoneMemoryStatus{}, fmt.Errorf("读取祝福焦点指令失败: %w", err)
@@ -85,6 +110,28 @@ func (a *App) WrightstoneMemoryGetStatus() (WrightstoneMemoryStatus, error) {
 		}
 	}
 	return a.readWrightstoneMemoryStatus()
+}
+
+func (a *App) resolveWrightstoneMemoryHook() (uintptr, error) {
+	mask := append([]bool{}, wrightstoneMemorySelectedMask...)
+	for i := 0; i < wrightstoneMemoryHookSize && i < len(mask); i++ {
+		mask[i] = false
+	}
+	matches, err := a.scanPatternAll(wrightstoneMemorySelectedPattern, mask)
+	if err != nil {
+		return 0, err
+	}
+	for i := len(matches) - 1; i >= 0; i-- {
+		addr := matches[i]
+		probe := make([]byte, wrightstoneMemoryHookSize)
+		if err := readProcessMemory(a.hProcess, addr, unsafe.Pointer(&probe[0]), uintptr(len(probe))); err != nil {
+			continue
+		}
+		if isWrightstoneMemoryOriginal(probe) || isWrightstoneMemoryJump(probe) {
+			return addr, nil
+		}
+	}
+	return 0, fmt.Errorf("未找到祝福焦点特征码；当前游戏版本与内置特征不匹配")
 }
 
 func (a *App) WrightstoneMemoryDisable() (WrightstoneMemoryStatus, error) {
@@ -149,8 +196,12 @@ func (a *App) WrightstoneMemoryUpdate(update WrightstoneMemoryUpdate) (Wrightsto
 			return WrightstoneMemoryStatus{}, fmt.Errorf("写入祝福词条失败: %w", err)
 		}
 	}
+	fn, err := a.resolveItemSaveFunction()
+	if err != nil {
+		return WrightstoneMemoryStatus{}, err
+	}
 	for _, offset := range []uintptr{0, 4, 8, 0x0C, 0x10, 0x14} {
-		if err := a.callRemoteOneArg(a.moduleBase+wrightstoneMemorySaveRVA, base+offset); err != nil {
+		if err := a.callRemoteOneArg(fn, base+offset); err != nil {
 			return WrightstoneMemoryStatus{}, fmt.Errorf("保存祝福字段 +0x%02X 失败: %w", offset, err)
 		}
 	}


### PR DESCRIPTION
## Summary
- 将「因子生成-新」「祝福生成-新」的 Hook 改为运行时 AOB 扫描，不再依赖固定 RVA
- 两者写入时共用的游戏内保存入口（原固定 Save RVA）改为特征扫描；Hook 点前 8 字节通配，兼容已安装 Hook
- 在 2.0.2 / 2.0.3 的 `granblue_fantasy_relink.exe` 上离线校验过特征均可命中，并在游戏中实测通过

## Test plan
- [x] 游戏 2.0.3/2.0.2：开启因子生成-新，读取选中因子并写入
- [x] 游戏 2.0.3/2.0.2：开启祝福生成-新，读取选中祝福并写入
- [x] 关闭功能后再次开启，确认可重新定位（已 Hook 状态）

## Notes
优化分支，用于抗小版本更新